### PR TITLE
Verify Hibernation allowed from Control plane before setting swap file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 *.o
 hibernation-setup-tool
+.vscode

--- a/hibernation-setup-tool.c
+++ b/hibernation-setup-tool.c
@@ -624,11 +624,9 @@ static bool is_hibernation_allowed_for_vm(void)
     if (bytes < 0)
         perror("Failed to write to socket");
 
-
-    while(read(sockfd, response, sizeof(response) - 1) != 0){
-		fprintf(stderr, "%s", response);
-		bzero(response, sizeof(response));
-	}
+    bytes = read(sockfd, response, sizeof(response) - 1);
+    if (bytes < 0)
+        perror("Failed to read from socket");
 
     // /* receive the response */
     // memset(response,0,sizeof(response));

--- a/hibernation-setup-tool.c
+++ b/hibernation-setup-tool.c
@@ -569,7 +569,7 @@ static bool is_hibernation_allowed_for_vm(void)
     /* first where are we going to send it? */
     int portno = 80;
     char *host = "169.254.169.254";
-    char *request = "GET /metadata/instance/compute/additionalCapabilities?api-version=2021-11-01 HTTP/1.1\r\nAccept: */*\r\nMetadata:true\r\n";
+    char *request = "GET /metadata/instance/compute/additionalCapabilities?api-version=2021-11-01 HTTP/1.1\r\nHost: 169.254.169.254\r\nMetadata:true\r\n\r\n";
 
     struct hostent *server;
     struct sockaddr_in serv_addr;
@@ -577,7 +577,7 @@ static bool is_hibernation_allowed_for_vm(void)
     char response[4096];
     
     /* What are we going to send? */
-    log_info("Request:\n%s\n",request);
+    log_info("Request:%s\n",request);
 
     /* create the socket */
     sockfd = socket(AF_INET, SOCK_STREAM, 0);

--- a/hibernation-setup-tool.c
+++ b/hibernation-setup-tool.c
@@ -644,7 +644,7 @@ static bool is_hibernation_allowed_for_vm(void)
         return false;
     }
 
-    /* 
+    /*
         Sample response -
             HTTP/1.1 200 OK
             Content-Type: text/plain; charset=utf-8

--- a/hibernation-setup-tool.c
+++ b/hibernation-setup-tool.c
@@ -567,9 +567,13 @@ static bool is_hibernation_enabled_for_vm(void)
 static bool is_hibernation_allowed_for_vm(void)
 {   
     /* first where are we going to send it? */
+    char *imds_host = "169.254.169.254";
+    char req[] = "GET /metadata/instance/compute/additionalCapabilities?api-version=2021-11-01 HTTP/1.1\r\nHost: %s\r\nMetadata:true\r\n\r\n";
+    
+    int request_length = strlen(req) + strlen(imds_host);
+    char request[request_length];
+    sprintf(request, req, imds_host);
     int portno = 80;
-    char *host = "169.254.169.254";
-    char *request = "GET /metadata/instance/compute/additionalCapabilities?api-version=2021-11-01 HTTP/1.1\r\nHost: 169.254.169.254\r\nMetadata:true\r\n\r\n";
 
     struct hostent *server;
     struct sockaddr_in serv_addr;
@@ -577,7 +581,7 @@ static bool is_hibernation_allowed_for_vm(void)
     char response[4096];
     
     /* What are we going to send? */
-    log_info("Request:%s\n",request);
+    log_info("Request:\n%s\n",request);
 
     /* create the socket */
     sockfd = socket(AF_INET, SOCK_STREAM, 0);
@@ -599,7 +603,7 @@ static bool is_hibernation_allowed_for_vm(void)
     }
 
     /* lookup the ip address */
-    server = gethostbyname(host);
+    server = gethostbyname(imds_host);
     if (server == NULL) 
     {
         perror("ERROR, no such host");
@@ -623,7 +627,7 @@ static bool is_hibernation_allowed_for_vm(void)
     total = strlen(request);
     sent = 0;
     do {
-        bytes = write(sockfd,request+sent,total-sent);
+        bytes = write(sockfd,&request+sent,total-sent);
         if (bytes < 0)
         {
             perror("ERROR writing message to socket");

--- a/hibernation-setup-tool.c
+++ b/hibernation-setup-tool.c
@@ -565,7 +565,7 @@ static bool is_hibernation_enabled_for_vm(void)
 }
 
 #define IMDSHOST "169.254.169.254"
-#define REQUEST "GET /metadata/instance/compute/additionalCapabilities?api-version=2021-11-01 HTTP/1.1\r\nHost: " IMDSHOST "\r\nMetadata:true\r\n\r\n"
+#define REQUEST "GET /metadata/instance/compute/additionalCapabilities/hibernationEnabled?api-version=2021-11-01&format=text HTTP/1.1\r\nHost: " IMDSHOST "\r\nMetadata:true\r\n\r\n"
 
 static bool is_hibernation_allowed_for_vm(void)
 {   
@@ -573,7 +573,7 @@ static bool is_hibernation_allowed_for_vm(void)
 
     struct hostent *server;
     struct sockaddr_in serv_addr;
-    int sockfd, bytes, sent, received, total;
+    int sockfd, bytes;
     char response[4096];
     
     /* What are we going to send? */
@@ -620,44 +620,20 @@ static bool is_hibernation_allowed_for_vm(void)
     }
 
     /* send the request */
-    bytes = write(sockfd, &REQUEST, strlen(REQUEST)); // write(fd, char[]*, len);  
+    bytes = write(sockfd, &REQUEST, strlen(REQUEST)); 
     if (bytes < 0)
         perror("Failed to write to socket");
 
+    // Get the response
     bytes = read(sockfd, response, sizeof(response) - 1);
     if (bytes < 0)
         perror("Failed to read from socket");
 
-    // /* receive the response */
-    // memset(response,0,sizeof(response));
-    // total = sizeof(response)-1;
-    // received = 0;
-    // do {
-    //     bytes = read(sockfd,response+received,total-received);
-    //     if (bytes < 0)
-    //     {
-    //         perror("ERROR reading response from socket");
-    //         return false;
-    //     }
-    //     if (bytes == 0)
-    //         break;
-    //     received+=bytes;
-    // } while (received < total);
-
-    /*
-     * if the number of received bytes is the total size of the
-     * array then we have run out of space to store the response
-     * and it hasn't all arrived yet - so that's a bad thing
-     */
-    // if (received == total)
-    //     perror("ERROR storing complete response from socket");
-
     /* close the socket */
-    shutdown(sockfd, SHUT_RDWR);
     close(sockfd);
 
     /* process response */
-    log_info("Response:\n%s\n",response);
+    log_info("IMDS Response:\n%s\n",response);
     return false;
 }
 

--- a/hibernation-setup-tool.c
+++ b/hibernation-setup-tool.c
@@ -563,7 +563,7 @@ static bool is_hibernation_enabled_for_vm(void)
     return false;
 }
 
-static int get_socket(const char *host, int portno)
+static int open_and_get_socket(const char *host, int portno)
 {
     struct hostent *server;
     struct sockaddr_in serv_addr;
@@ -624,7 +624,7 @@ static bool is_hibernation_allowed_for_vm(void)
     char request[req_size];
     snprintf(request, req_size, imds_req, imds_host);
     
-    sockfd = get_socket(imds_host, portno);
+    sockfd = open_and_get_socket(imds_host, portno);
     if(sockfd < 0)
         return false;
         

--- a/hibernation-setup-tool.c
+++ b/hibernation-setup-tool.c
@@ -669,7 +669,7 @@ static bool is_hibernation_allowed_for_vm(void)
         close(sockfd);
         return false;
     }
-    
+
     response[read_bytes] = '\0';
 
     /* close the socket */

--- a/hibernation-setup-tool.c
+++ b/hibernation-setup-tool.c
@@ -620,33 +620,42 @@ static bool is_hibernation_allowed_for_vm(void)
     }
 
     /* send the request */
-    write(sockfd, &REQUEST, strlen(REQUEST)); // write(fd, char[]*, len);  
+    bytes = write(sockfd, &REQUEST, strlen(REQUEST)); // write(fd, char[]*, len);  
+    if (bytes < 0)
+        perror("Failed to write to socket");
 
-    /* receive the response */
-    memset(response,0,sizeof(response));
-    total = sizeof(response)-1;
-    received = 0;
-    do {
-        bytes = read(sockfd,response+received,total-received);
-        if (bytes < 0)
-        {
-            perror("ERROR reading response from socket");
-            return false;
-        }
-        if (bytes == 0)
-            break;
-        received+=bytes;
-    } while (received < total);
+
+    while(read(sockfd, response, sizeof(response) - 1) != 0){
+		fprintf(stderr, "%s", response);
+		bzero(response, sizeof(response));
+	}
+
+    // /* receive the response */
+    // memset(response,0,sizeof(response));
+    // total = sizeof(response)-1;
+    // received = 0;
+    // do {
+    //     bytes = read(sockfd,response+received,total-received);
+    //     if (bytes < 0)
+    //     {
+    //         perror("ERROR reading response from socket");
+    //         return false;
+    //     }
+    //     if (bytes == 0)
+    //         break;
+    //     received+=bytes;
+    // } while (received < total);
 
     /*
      * if the number of received bytes is the total size of the
      * array then we have run out of space to store the response
      * and it hasn't all arrived yet - so that's a bad thing
      */
-    if (received == total)
-        perror("ERROR storing complete response from socket");
+    // if (received == total)
+    //     perror("ERROR storing complete response from socket");
 
     /* close the socket */
+    shutdown(sockfd, SHUT_RDWR);
     close(sockfd);
 
     /* process response */

--- a/hibernation-setup-tool.service
+++ b/hibernation-setup-tool.service
@@ -1,5 +1,7 @@
 [Unit]
 Description=Hibernation Setup Tool
+After=network-online.target
+Wants=network-online.target
 
 [Service]
 Type=simple
@@ -9,5 +11,3 @@ StandardOutput=journal
 
 [Install]
 WantedBy=multi-user.target
-After=network-online.target
-Wants=network-online.target

--- a/hibernation-setup-tool.service
+++ b/hibernation-setup-tool.service
@@ -9,3 +9,5 @@ StandardOutput=journal
 
 [Install]
 WantedBy=multi-user.target
+After=network-online.target
+Wants=network-online.target


### PR DESCRIPTION
Currently the hibernation-setup tool would run even if Hibernation was not enabled for the VM during creation time. 
This PR verifies the hibernation state from IMDS and only proceeds with setup if enabled from CRP.  