### PR TITLE
Device free space - swap file creation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,9 @@ hibernation-setup-tool: $(OBJS)
 
 all: hibernation-setup-tool
 
+debug: CFLAGS += -DDEBUG -g
+debug: hibernation-setup-tool
+
 .PHONY: clean
 clean:
 	rm -f $(OBJS)

--- a/hibernation-setup-tool.c
+++ b/hibernation-setup-tool.c
@@ -849,10 +849,11 @@ static bool try_zeroing_out_with_fallocate(const char *path, off_t size)
     }
 
     if (fallocate(fd, 0, 0, size) < 0) {
+        int fallocate_errno = errno; 
         if (unlink(path) < 0)
             log_info("Couldn't remove incomplete hibernation file %s: %s", path, strerror(errno));
 
-        if (errno == ENOSPC) {
+        if (fallocate_errno == ENOSPC) {
             log_fatal("System ran out of disk space while allocating hibernation file. It needs %zd MiB", size / MEGA_BYTES);
         } else {
             log_fatal("Could not allocate %s: %s", path, strerror(errno));

--- a/hibernation-setup-tool.c
+++ b/hibernation-setup-tool.c
@@ -856,7 +856,7 @@ static bool try_zeroing_out_with_fallocate(const char *path, off_t size)
         if (fallocate_errno == ENOSPC) {
             log_fatal("System ran out of disk space while allocating hibernation file. It needs %zd MiB", size / MEGA_BYTES);
         } else {
-            log_fatal("Could not allocate %s: %s", path, strerror(errno));
+            log_fatal("Could not allocate %s: %s", path, strerror(fallocate_errno));
         }
     }
 


### PR DESCRIPTION
https://msazure.visualstudio.com/One/_workitems/edit/14779231/

Problem: When creating a swap file that is larger than the available device space, fallocate fails, and in turn takes up as much available device space as it can without cleaning itself up. 

Solution: Ensure that if fallocate fails it releases its taken memory. And detect before creating a swap file whether we will have enough space to store it, and if not don't attempt creating it. 

1. Check free space available on device is enough to create swap file
2. Released disk space used from failed fallocate calls
3. Included debug rule in Makefile
4. Clang Formatted hibernation-setup-tool.c