### PR TITLE
Bug in finding swap file - strcmp

### DIFF
--- a/hibernation-setup-tool.c
+++ b/hibernation-setup-tool.c
@@ -258,17 +258,18 @@ static struct swap_file *find_swap_file(size_t needed_size)
             break;
         }
 
-        if (!strcmp(type, "file")) {
+        if (!strncmp(type, "file", sizeof("file") - 1)) {
             char *size = next_field(type);
 
             if (!size)
                 log_fatal("Malformed line in /proc/swaps: can't find size column");
 
-            size_t size_as_int = parse_size_or_die(size, ' ', NULL);
-            if (size_as_int < needed_size)
+	    size_t size_as_int_kb = parse_size_or_die(size, ' ', NULL);
+	    size_t size_as_int_b = size_as_int_kb * 1024;
+	    if (size_as_int_b < needed_size)
                 continue;
 
-            out = new_swap_file(filename, size_as_int);
+            out = new_swap_file(filename, size_as_int_b);
             break;
         }
     }


### PR DESCRIPTION
This PR can be used as conversation. I have a concern with find swap file function. Previously the `!strcmp(type, "file")` would never evaluate to true, because `type` is a non null-terminated field from the /proc/swaps file. The `type` string would include total size, used size, and priority in the same line.

Correcting this line to `strncmp`, raised other concerns, however: 
1. On my machine the first swap file happens to be `/hiberfile.sys`. What if it isn't? Is this reliable
2. While the size stored in `/proc/swaps` on my machine is in kb will this be true on all machines
3. Is this method more reliable/preferred then the backup method which simply checks stat size on `/hiberfile.sys`