### PR TITLE
is_cold_boot - return value fix 

### DIFF
--- a/hibernation-setup-tool.c
+++ b/hibernation-setup-tool.c
@@ -1434,7 +1434,7 @@ static bool is_cold_boot(void)
     if (lock_file_path) {
         unlink(hibernate_lock_file_name);
 
-        if (access(lock_file_path, F_OK) < 0)
+        if (!access(lock_file_path, F_OK))
             return false;
 
         unlink(lock_file_path);

--- a/hibernation-setup-tool.c
+++ b/hibernation-setup-tool.c
@@ -1431,12 +1431,12 @@ static bool is_cold_boot(void)
         unlink(hibernate_lock_file_name);
 
         if (access(lock_file_path, F_OK) < 0)
-            return true;
+            return false;
 
         unlink(lock_file_path);
     }
 
-    return false;
+    return true;
 }
 
 static void notify_vm_host(enum host_vm_notification notification)


### PR DESCRIPTION
If the file in tmpfs filesystem is present during agent startup, is_cold_boot should return false. 

If it is not present during agent startup, is_cold_boot should return true. 