### PR TITLE
Ensure systemd hooks setup

### DIFF
--- a/hibernation-setup-tool.c
+++ b/hibernation-setup-tool.c
@@ -1694,8 +1694,6 @@ static void ensure_systemd_hooks_are_set_up(void)
         char *execfn_file_name = strrchr(execfn, '/') + 1; 
 
         snprintf(location_to_link_file, sizeof(location_to_link_file), "%s%s%s", location_to_link_dir, "/", execfn_file_name);
-        log_info("location to link file: %s", location_to_link_file);
-
         return link_hook(execfn, location_to_link_file);
     }
 
@@ -1708,8 +1706,6 @@ static void ensure_systemd_hooks_are_set_up(void)
         char *exe_file_name = strrchr(self_path, '/') + 1;
 
         snprintf(location_to_link_file, sizeof(location_to_link_file), "%s%s%s", location_to_link_dir, "/", exe_file_name);
-        log_info("location to link file %s", location_to_link_file);
-
         return link_hook(self_path, location_to_link_file);
     }
 

--- a/hibernation-setup-tool.c
+++ b/hibernation-setup-tool.c
@@ -1700,7 +1700,6 @@ static void ensure_systemd_hooks_are_set_up(void)
     char self_path_buf[PATH_MAX];
     const char *self_path = readlink0("/proc/self/exe", self_path_buf);
 
-    log_info("exe path: %s", self_path);
     if (self_path){
         char location_to_link_file[PATH_MAX]; 
         char *exe_file_name = strrchr(self_path, '/') + 1;


### PR DESCRIPTION
Currently link_hook command fails every time because second parameter to function is a directory not a filename. This has been corrected here with full file path as second parameter. 