### PR TITLE
Resolve syslogging bug

### DIFF
--- a/hibernation-setup-tool.c
+++ b/hibernation-setup-tool.c
@@ -101,8 +101,12 @@ static int ioprio_set(int which, int who, int ioprio) { return (int)syscall(SYS_
 
 static void log_impl(int log_level, const char *fmt, va_list ap)
 {
-    if (log_needs_syslog)
-        vsyslog(log_level, fmt, ap);
+    if (log_needs_syslog){
+        va_list ap_cpy; 
+        va_copy(ap_cpy, ap);
+        vsyslog(log_level, fmt, ap_cpy); 
+        va_end(ap_cpy); 
+    }
 
     flockfile(stdout);
 


### PR DESCRIPTION
Currently if we want to write to both syslog and stdout, we need to create a copy of our variable arguments list. This is because vsyslog and vprintf set our va_list to the end after being used. In short, va_list is not reusable and needs a copy of it to be made in order to print out to both syslog and stdout.