### PR TITLE
Minor makefile debug addition

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ hibernation-setup-tool: $(OBJS)
 
 all: hibernation-setup-tool
 
-debug: CFLAGS += -DDEBUG -g
+debug: CFLAGS += -DDEBUG -g -O0
 debug: hibernation-setup-tool
 
 .PHONY: clean


### PR DESCRIPTION
Added optimization flag to improve debugging experience. Prevents variables from being optimized out. 

Given there is another optimization flag: -Os

From man pages: 

`If you use multiple -O options, with or without level numbers, the last such option is the one that is effective.`

https://linux.die.net/man/1/gcc