### PR TITLE
Fixing hooks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ hibernation-setup-tool: $(OBJS)
 
 all: hibernation-setup-tool
 
-debug: CFLAGS += -DDEBUG -g
+debug: CFLAGS += -DDEBUG -g -O0
 debug: hibernation-setup-tool
 
 .PHONY: clean

--- a/hibernation-setup-tool.c
+++ b/hibernation-setup-tool.c
@@ -1694,8 +1694,6 @@ static void ensure_systemd_hooks_are_set_up(void)
         char *execfn_file_name = strrchr(execfn, '/') + 1; 
 
         snprintf(location_to_link_file, sizeof(location_to_link_file), "%s%s%s", location_to_link_dir, "/", execfn_file_name);
-        log_info("location to link file: %s", location_to_link_file);
-
         return link_hook(execfn, location_to_link_file);
     }
 
@@ -1708,8 +1706,6 @@ static void ensure_systemd_hooks_are_set_up(void)
         char *exe_file_name = strrchr(self_path, '/') + 1;
 
         snprintf(location_to_link_file, sizeof(location_to_link_file), "%s%s%s", location_to_link_dir, "/", exe_file_name);
-        log_info("location to link file %s", location_to_link_file);
-
         return link_hook(self_path, location_to_link_file);
     }
 

--- a/hibernation-setup-tool.c
+++ b/hibernation-setup-tool.c
@@ -1700,7 +1700,6 @@ static void ensure_systemd_hooks_are_set_up(void)
     char self_path_buf[PATH_MAX];
     const char *self_path = readlink0("/proc/self/exe", self_path_buf);
 
-    log_info("exe path: %s", self_path);
     if (self_path){
         char location_to_link_file[PATH_MAX]; 
         char *exe_file_name = strrchr(self_path, '/') + 1;

--- a/hibernation-setup-tool.c
+++ b/hibernation-setup-tool.c
@@ -1577,8 +1577,9 @@ static int handle_pre_systemd_suspend_notification(const char *action)
         }
 
         if (symlink(pattern, hibernate_lock_file_name) < 0) {
+            int symlink_errno = errno;
             notify_vm_host(HOST_VM_NOTIFY_PRE_HIBERNATION_FAILED);
-            log_fatal("Couldn't symlink %s to %s: %s", pattern, hibernate_lock_file_name, strerror(errno));
+            log_fatal("Couldn't symlink %s to %s: %s", pattern, hibernate_lock_file_name, strerror(symlink_errno));
         }
 
         notify_vm_host(HOST_VM_NOTIFY_HIBERNATING);

--- a/hibernation-setup-tool.c
+++ b/hibernation-setup-tool.c
@@ -1494,7 +1494,7 @@ static int recursive_rmdir_cb(const char *fpath, const struct stat *st, int type
     }
 }
 
-static bool recursive_rmdir(const char *path) { return nftw(path, recursive_rmdir_cb, 16, FTW_DEPTH | FTW_PHYS | FTW_ACTIONRETVAL) != FTW_STOP; }
+static bool recursive_rmdir(const char *path) { return nftw(path, recursive_rmdir_cb, 16, FTW_DEPTH | FTW_PHYS | FTW_ACTIONRETVAL) == 0; }
 
 static int handle_pre_systemd_suspend_notification(const char *action)
 {

--- a/hibernation-setup-tool.c
+++ b/hibernation-setup-tool.c
@@ -1539,15 +1539,13 @@ static int handle_pre_systemd_suspend_notification(const char *action)
                     log_fatal("Couldn't remove /tmp/hibernation-setup-tool directory before proceeding");
                 }
 
-                else {
-                    log_info("/tmp/hibernation-setup-tool exists and isn't a directory! Removing it and trying again (try %d)", try);
+                log_info("/tmp/hibernation-setup-tool exists and isn't a directory! Removing it and trying again (try %d)", try);
 
-                    if (!unlink("/tmp/hibernation-setup-tool"))
-                        continue;
+                if (!unlink("/tmp/hibernation-setup-tool"))
+                    continue;
 
-                    notify_vm_host(HOST_VM_NOTIFY_PRE_HIBERNATION_FAILED);
-                    log_fatal("Couldn't remove the file: %s, giving up", strerror(errno));
-                }
+                notify_vm_host(HOST_VM_NOTIFY_PRE_HIBERNATION_FAILED);
+                log_fatal("Couldn't remove the file: %s, giving up", strerror(errno));
             }
 
             log_info("/tmp/hibernation-setup-tool couldn't be found but mkdir() told us it exists, trying again (try %d)", try);


### PR DESCRIPTION
This code fixes existing bugs in pre and post hooks tool code. Some of the fixes include:
1. Error handling of hibernate lock file
2. Invalid cross device linking of file
3. Fixed incomplete recursive removal of folder

The PR also removes the old method for ensuring hooks are set up, in favor of the new sleep hooks method using service files implemented in https://github.com/microsoft/hibernation-setup-tool/pull/7 

Reason for removing old method can be seen in closing comment here: https://github.com/microsoft/hibernation-setup-tool/pull/8

“Note that scripts or binaries dropped in /usr/lib/systemd/system-sleep/ are intended for local use only and should be considered hacks.” - [systemd-suspend.service (www.freedesktop.org)](https://www.freedesktop.org/software/systemd/man/systemd-suspend.service.html)