### PR TITLE
Ensuring swap file gets recreated when user downsizes their VM

### DIFF
--- a/hibernation-setup-tool.c
+++ b/hibernation-setup-tool.c
@@ -1747,7 +1747,7 @@ int main(int argc, char *argv[])
         log_info("Swap file not found");
     }
 
-    if (swap && swap->capacity < needed_swap) {
+    if (swap && swap->capacity != needed_swap) {
         log_info("Swap file %s has capacity of %zu MB but needs %zu MB. Recreating. "
                  "System will run without a swap file while this is being set up.",
                  swap->path, swap->capacity / MEGA_BYTES, needed_swap / MEGA_BYTES);


### PR DESCRIPTION
I wanted to make this minor addition its own PR. 

Currently if a user switches to a VM with lower RAM size, the swap file will not get recreated accordingly. This check ensures the swap file is of right size and recreates it in the case a user reduces their VM size. 