### PR TITLE
Tool takes long time to return, and swap file not created successfully for RHEL distros

### DIFF
--- a/hibernation-setup-tool.c
+++ b/hibernation-setup-tool.c
@@ -960,6 +960,9 @@ static void spawn_and_wait(const char *program, int n_args, ...)
 
 static void perform_fs_specific_checks(const char *path)
 {
+    /* Not performing defragmentation for xfs file systems as xfs_fsr process is taking time for SKUs with larger RAM.
+       While it is good to have optimization, not ideal to have performance hit on the tool */
+
     if (is_file_on_fs(path, EXT4_SUPER_MAGIC) && is_exec_in_path("e4defrag")) {
         try_spawn_and_wait("e4defrag", 1, path);
         return;

--- a/hibernation-setup-tool.c
+++ b/hibernation-setup-tool.c
@@ -979,11 +979,6 @@ static void perform_fs_specific_checks(const char *path)
             try_spawn_and_wait("btrfs", 3, "filesystem", "defragment", path);
         return;
     }
-
-    if (is_file_on_fs(path, XFS_SUPER_MAGIC) && is_exec_in_path("xfs_fsr")) {
-        try_spawn_and_wait("xfs_fsr", 2, "-v", path);
-        return;
-    }
 }
 
 bool is_kernel_version_at_least(const char *version)


### PR DESCRIPTION
For XFS file systems, tool is using xfs_fsr process for defragmentation on swap file which would improve performance when storing and accessing large files.

Documentation - [xfs_fsr(8) - Linux manual page (man7.org)](https://www.man7.org/linux/man-pages/man8/xfs_fsr.8.html)

But for SKUs with larger memory size, process is taking longer to perform optimization. It is mostly noticed on SKUs with 32 GB RAM with 128 GB disk size. While it is ideal to have that, would be performance hit on the tool. 

Also as per the above document - In general we do not foresee the need to run xfs_fsr on system partitions such as /, /boot and /usr as in general these will not suffer from fragmentation.

So, removing the optimization part from critical path for XFS file systems to improve performance of tool.